### PR TITLE
Speed up preloads with duplicate code points

### DIFF
--- a/adafruit_bitmap_font/bdf.py
+++ b/adafruit_bitmap_font/bdf.py
@@ -94,9 +94,9 @@ class BDF(GlyphCache):
             remaining.add(code_points)
         else:
             remaining = set(code_points)
-        for cp in remaining:
-            if cp in self._glyphs and self._glyphs[cp]:
-                remaining.remove(cp)
+        for code_point in remaining:
+            if code_point in self._glyphs and self._glyphs[code_point]:
+                remaining.remove(code_point)
         if not remaining:
             return
 


### PR DESCRIPTION
The original logic wouldn't recognize duplicate characters
in the given set to preload and therefore it'd read the whole
font file looking for a character it already found. A set
deduplicates the given characters at a small memory cost.

This drops the font preload for PyPortal from 22 seconds
to just over 2 seconds. (The preload string has duplicate
exclamation points.)