### PR TITLE
setup.py fixes for correct pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(
     # simple. Or you can use find_packages().
     # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
     #       CHANGE `py_modules=['...']` TO `packages=['...']`
-    py_modules=["adafruit_bitmap_font"],
+    packages=["adafruit_bitmap_font"],
 )


### PR DESCRIPTION
Addressing #18 , the PyPI installation was only installing the *.egg-info directory and did not install the library itself. This happened when I used `pip3 install adafruit-circuitpython-bitmap_font` and when I tried to pip install directly from the *.tar.gz file.

By making this change, I was able to install correctly from the *.tar.gz file 😀.