### PR TITLE
Removing 3.0.0 compatibility.

### DIFF
--- a/adafruit_bitmap_font/bdf.py
+++ b/adafruit_bitmap_font/bdf.py
@@ -40,7 +40,7 @@ Implementation Notes
 """
 
 import gc
-from displayio import Glyph
+from fontio import Glyph
 from .glyph_cache import GlyphCache
 
 __version__ = "0.0.0-auto.0"

--- a/adafruit_bitmap_font/bdf.py
+++ b/adafruit_bitmap_font/bdf.py
@@ -40,11 +40,7 @@ Implementation Notes
 """
 
 import gc
-
-try:
-    from displayio import Glyph
-except ImportError:
-    from fontio import Glyph
+from displayio import Glyph
 from .glyph_cache import GlyphCache
 
 __version__ = "0.0.0-auto.0"


### PR DESCRIPTION
Fixes #9 

Requires testing of bdf.py file.