### PR TITLE
Make a copy of the set to iterate over, not the original set we will …

### DIFF
--- a/adafruit_bitmap_font/bdf.py
+++ b/adafruit_bitmap_font/bdf.py
@@ -97,7 +97,7 @@ class BDF(GlyphCache):
             remaining = code_points
         else:
             remaining = set(code_points)
-        for code_point in remaining:
+        for code_point in remaining.copy():
             if code_point in self._glyphs and self._glyphs[code_point]:
                 remaining.remove(code_point)
         if not remaining:


### PR DESCRIPTION
Added .copy() to the iteration of code_point over the set named "remaining." This is so we avoid iterating over the set as we removed items from it.