### PR TITLE
Fix 2.6.0 lint

### DIFF
--- a/examples/bitmap_font_displayio_simpletest.py
+++ b/examples/bitmap_font_displayio_simpletest.py
@@ -8,8 +8,8 @@ bitmap with pixels matching glyphs from a given String
 
 
 import board
-from adafruit_bitmap_font import bitmap_font  # pylint: disable=wrong-import-position
 import displayio
+from adafruit_bitmap_font import bitmap_font
 
 font = bitmap_font.load_font("fonts/Arial-16.bdf")
 

--- a/examples/bitmap_font_label_simpletest.py
+++ b/examples/bitmap_font_label_simpletest.py
@@ -4,8 +4,8 @@ loaded by adafruit_bitmap_font
 """
 
 import board
-from adafruit_bitmap_font import bitmap_font
 from adafruit_display_text import label
+from adafruit_bitmap_font import bitmap_font
 
 display = board.DISPLAY
 


### PR DESCRIPTION
@FoamyGuy why was the order different in the displayio_simpletest to begin with? The disable has the wrong term so I'm surprised it worked at all.