### PR TITLE
Optimize bdf

### DIFF
--- a/adafruit_bitmap_font/bdf.py
+++ b/adafruit_bitmap_font/bdf.py
@@ -63,6 +63,41 @@ class BDF(GlyphCache):
         self.point_size = None
         self.x_resolution = None
         self.y_resolution = None
+        self._ascent = None
+        self._descent = None
+
+    @property
+    def descent(self):
+        """The number of pixels below the baseline of a typical descender"""
+        if self._descent is None:
+            self.file.seek(0)
+            while True:
+                line = self.file.readline()
+                if not line:
+                    break
+
+                if line.startswith(b"FONT_DESCENT "):
+                    self._descent = int(line.split()[1])
+                    break
+
+        return self._descent
+
+    @property
+    def ascent(self):
+        """The number of pixels above the baseline of a typical ascender"""
+        if self._ascent is None:
+            self.file.seek(0)
+            while True:
+                line = self.file.readline()
+                line = str(line, "utf-8")
+                if not line:
+                    break
+
+                if line.startswith("FONT_ASCENT "):
+                    self._ascent = int(line.split()[1])
+                    break
+
+        return self._ascent
 
     def get_bounding_box(self):
         """Return the maximum glyph size as a 4-tuple of: width, height, x_offset, y_offset"""


### PR DESCRIPTION
Loading fonts can be one of the slow phases of a Magtag type project, and run time decreases battery lifetime.  Therefore, it's warranted to write less idiomatic Python here if it improves runtime significantly.

This change assumes that the lines within a character come in a specific order.  While the document ostensibly [defining the BDF file format](https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/5005.BDF_Spec.pdf) does not say that the order is defined, I inspected the source of the Linux program "bdftopcf" which has been used for decades to convert textual bdf font files into binary pcf files, and it too assumes that the lines come in a defined order.  I doubt that bdf files that do not work with the linux bdftopcf program are less scarce than unicorns.

I timed loading the characters "Adafruit CircuitPython" from the font "GothamBlack-50.bdf" on a PyBadge in CircuitPython 6.0.0:

```python
font = load_font("/GothamBlack-50.bdf")
font.load_glyphs("Adafruit CircuitPython")
```

The time decreased from 919ms to 530ms (-42%).

Just reading all the lines in the font file takes 380ms.  However, only the first 38% of the file (or so) needs to be read, so the I/O time is about 140ms.

Ascent and descent properties are also added.  When the corresponding fix is taken in Adafruit_CircuitPython_DisplayText, these avoid an additional potential read of the font file to find glyphs which are likely to have large ascents and descents, giving further speed improvements. 