### PR TITLE
Adding pcf font files to example scripts. Few other fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Introduction
     :target: https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font/actions/
     :alt: Build Status
 
-Loads bitmap fonts into CircuitPython's displayio. BDF files are well supported. PCF and TTF
+Loads bitmap fonts into CircuitPython's displayio. BDF and PCF files are well supported. TTF
 support is not yet complete.
 
 Dependencies
@@ -53,11 +53,11 @@ To install in a virtual environment in your current project:
 Usage Example
 =============
 
-.. code-block::python
+.. code-block:: python
 
     from adafruit_bitmap_font import bitmap_font
     from displayio import Bitmap
-    font = bitmap_font.load_font("scientifica-11.bdf", Bitmap)
+    font = bitmap_font.load_font("fonts/Arial-16.bdf", Bitmap)
     print(font.get_glyph(ord("A")))
 
 

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,15 @@ Usage Example
     print(font.get_glyph(ord("A")))
 
 
+Creating Fonts
+==============
+
+See `this learn guide <https://learn.adafruit.com/custom-fonts-for-pyportal-circuitpython-display>`_ for more information about building custom fornt files
+
+The command line tool :code:`otf2bdf` can be used make bdf files for use with this library.
+
+The command line tool :code:`bdftopcf` can be used make pcf files for use with this library.
+
 Contributing
 ============
 

--- a/examples/bitmap_font_displayio_simpletest.py
+++ b/examples/bitmap_font_displayio_simpletest.py
@@ -11,7 +11,16 @@ import board
 import displayio
 from adafruit_bitmap_font import bitmap_font
 
-font = bitmap_font.load_font("fonts/Arial-16.bdf")
+# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
+# https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
+display = board.DISPLAY
+
+# try uncommenting different font files if you like
+font_file = "fonts/Arial-16.bdf"
+# font_file = "fonts/yasashi24.pcf"
+
+font = bitmap_font.load_font(font_file)
 
 bitmap = displayio.Bitmap(320, 240, 2)
 
@@ -59,7 +68,7 @@ group.x = 20
 group.append(tile_grid)
 
 # Add the Group to the Display
-board.DISPLAY.show(group)
+display.show(group)
 
 while True:
     pass

--- a/examples/bitmap_font_label_magtag.py
+++ b/examples/bitmap_font_label_magtag.py
@@ -15,9 +15,13 @@ display = board.DISPLAY
 # wait until we can refresh the display
 time.sleep(display.time_to_refresh)
 
+# try uncommenting different font files if you like
+font_file = "fonts/Arial-16.bdf"
+# font_file = "fonts/yasashi24.pcf"
+
 # Set text, font, and color
 text = "HELLO WORLD\nbitmap_font example"
-font = bitmap_font.load_font("fonts/Arial-16.bdf")
+font = bitmap_font.load_font(font_file)
 color = 0xFFFFFF
 background_color = 0x999999
 

--- a/examples/bitmap_font_label_simpletest.py
+++ b/examples/bitmap_font_label_simpletest.py
@@ -7,11 +7,18 @@ import board
 from adafruit_display_text import label
 from adafruit_bitmap_font import bitmap_font
 
+# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
+# https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
 display = board.DISPLAY
+
+# try uncommenting different font files if you like
+font_file = "fonts/Arial-16.bdf"
+# font_file = "fonts/yasashi24.pcf"
 
 # Set text, font, and color
 text = "HELLO WORLD"
-font = bitmap_font.load_font("fonts/Arial-16.bdf")
+font = bitmap_font.load_font(font_file)
 color = 0xFF00FF
 
 # Create the tet label


### PR DESCRIPTION
Fixed an issue with the code block formatting of the usage example in the readme.

Added a section to the readme about creating font files to use with the library.

I also updated the displayio example to use a `display` variable and link to the display setup guide.

The updated example scripts were tested with PyPortal and MagTag devices.