### PR TITLE
pcf: Support vewwy big letters

### DIFF
--- a/adafruit_bitmap_font/pcf.py
+++ b/adafruit_bitmap_font/pcf.py
@@ -324,8 +324,8 @@ class PCF(GlyphCache):
             6 + self._bitmaps.glyph_count
         )
         metrics_compressed = self.tables[_PCF_METRICS].format & _PCF_COMPRESSED_METRICS
-        first_metric_offset = (
-            self.tables[_PCF_METRICS].offset + (6 if metrics_compressed else 8)
+        first_metric_offset = self.tables[_PCF_METRICS].offset + (
+            6 if metrics_compressed else 8
         )
         metrics_size = 5 if metrics_compressed else 12
 

--- a/adafruit_bitmap_font/pcf.py
+++ b/adafruit_bitmap_font/pcf.py
@@ -233,7 +233,7 @@ class PCF(GlyphCache):
         format_ = self._seek_table(accelerators)
 
         has_inkbounds = format_ & _PCF_ACCEL_W_INKBOUNDS
-        compressed_metrics = False  # format_ & _PCF_COMPRESSED_METRICS
+        compressed_metrics = format_ & _PCF_COMPRESSED_METRICS
 
         (
             no_overlap,
@@ -325,7 +325,7 @@ class PCF(GlyphCache):
         )
         metrics_compressed = self.tables[_PCF_METRICS].format & _PCF_COMPRESSED_METRICS
         first_metric_offset = (
-            self.tables[_PCF_METRICS].offset + 6 if metrics_compressed else 8
+            self.tables[_PCF_METRICS].offset + (6 if metrics_compressed else 8)
         )
         metrics_size = 5 if metrics_compressed else 12
 


### PR DESCRIPTION
When glyphs lie entirely within 127 pixels of the glyph origin, they get "compressed metrics".  Otherwise, they get "uncompressed
metrics".  Some of the calculations for "uncompressed metrics" were wrong.  This only affects extremely unusual or large point-size fonts, which is why it wasn't found initially.

Testing performed: rendered the letter 'a' at 200 points from pcf using the simpletest.