### PR TITLE
pcf: Use `bitmaptools.readinto` to load font data if available

### DIFF
--- a/adafruit_bitmap_font/pcf.py
+++ b/adafruit_bitmap_font/pcf.py
@@ -33,7 +33,7 @@ from .glyph_cache import GlyphCache
 try:
     from bitmaptools import readinto as _bitmap_readinto
 except ImportError:
-    _bitmap_readinto = None # pylint: disable=invalid-name
+    _bitmap_readinto = None  # pylint: disable=invalid-name
 
 _PCF_PROPERTIES = const(1 << 0)
 _PCF_ACCELERATORS = const(1 << 1)


### PR DESCRIPTION
Together with https://github.com/adafruit/circuitpython/pull/4403 this speeds up loading bitmap fonts by up to 10x (for truly large fonts, like 72pt arial bold).  Smaller font loading such as 12pt Arial Bold speeds up 2x. (when loading all ASCII glyphs 32..127 inclusive)

The code will continue to work on boards that don't have the new readinto function, at the same speed as before.