### PR TITLE
Including exception regarding missing FONTBOUNDINGBOX parameter

### DIFF
--- a/adafruit_bitmap_font/bdf.py
+++ b/adafruit_bitmap_font/bdf.py
@@ -121,7 +121,12 @@ class BDF(GlyphCache):
         if not remaining:
             return
 
-        x, _, _, _ = self.get_bounding_box()
+        try:
+            x, _, _, _ = self.get_bounding_box()
+        except TypeError as error:
+            raise Exception(
+                "Font file does not have the FONTBOUNDINGBOX property. Try a different font"
+            ) from error
 
         self.file.seek(0)
         while True:


### PR DESCRIPTION
Including exception regarding missing FONTBOUNDINGBOX parameter in the font file.

Will produce
```python
Exception: Font does not have the FONTBOUNDINGBOX property. Try a different font
```

Solves #25 