### PR TITLE
Exposing examples to the API documentation and other small changes

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,43 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/bitmap_font_simpletest.py
     :caption: examples/bitmap_font_simpletest.py
     :linenos:
+
+Label simple test
+-----------------
+
+This example uses ``adafruit_display_text.label`` to display text using a custom font
+loaded by ``adafruit_bitmap_font``
+
+.. literalinclude:: ../examples/bitmap_font_label_simpletest.py
+    :caption: examples/bitmap_font_label_simpletest.py
+    :linenos:
+
+Displayio simple test
+---------------------
+
+This example uses ``adafruit_bitmap_font`` to load a font and fill a bitmap with
+pixels matching glyphs from a given String
+
+.. literalinclude:: ../examples/bitmap_font_displayio_simpletest.py
+    :caption: examples/bitmap_font_displayio_simpletest.py
+    :linenos:
+
+Label MagTag
+------------
+
+This example uses ``adafruit_display_text.label`` to display text using a custom font
+loaded by ``adafruit_bitmap_font``.
+
+.. literalinclude:: ../examples/bitmap_font_label_magtag.py
+    :caption: examples/bitmap_font_label_magtag.py
+    :linenos:
+
+Fork Awesome icons
+------------------
+
+This example uses ``adafruit_display_text.label`` to display fork awesome
+icons.
+
+.. literalinclude:: ../examples/bitmap_font_label_forkawesome.py
+    :caption: examples/bitmap_font_label_forkawesome.py
+    :linenos:

--- a/examples/bitmap_font_displayio_simpletest.py
+++ b/examples/bitmap_font_displayio_simpletest.py
@@ -3,7 +3,7 @@
 
 """
 This example runs on PyPortal, or any Circuit Python device
-with a built-in screen that is at least 320x240 pixels.
+with a built-in screen.
 
 It will use adafruit_bitmap_font to load a font and fill a
 bitmap with pixels matching glyphs from a given String
@@ -14,7 +14,7 @@ import board
 import displayio
 from adafruit_bitmap_font import bitmap_font
 
-# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# use built in display (MagTag, PyPortal, PyGamer, PyBadge, CLUE, etc.)
 # see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
 # https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
 display = board.DISPLAY
@@ -25,7 +25,7 @@ font_file = "fonts/LeagueSpartan-Bold-16.bdf"
 
 font = bitmap_font.load_font(font_file)
 
-bitmap = displayio.Bitmap(320, 240, 2)
+bitmap = displayio.Bitmap(display.width, display.height, 2)
 
 palette = displayio.Palette(2)
 

--- a/examples/bitmap_font_label_forkawesome.py
+++ b/examples/bitmap_font_label_forkawesome.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-This example uses addfruit_display_text.label to display fork awesome
+This example uses adafruit_display_text.label to display fork awesome
 icons.
 
 More info here: https://emergent.unpythonic.net/01606790241
@@ -13,7 +13,7 @@ from forkawesome_icons import microchip, python, terminal
 from adafruit_display_text import label
 from adafruit_bitmap_font import bitmap_font
 
-# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# use built in display (MagTag, PyPortal, PyGamer, PyBadge, CLUE, etc.)
 # see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
 # https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
 display = board.DISPLAY

--- a/examples/bitmap_font_label_magtag.py
+++ b/examples/bitmap_font_label_magtag.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-This example uses addfruit_display_text.label to display text using a custom font
+This example uses adafruit_display_text.label to display text using a custom font
 loaded by adafruit_bitmap_font.
 Adapted for use on MagTag
 """
@@ -11,7 +11,7 @@ import board
 from adafruit_display_text import label
 from adafruit_bitmap_font import bitmap_font
 
-# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# use built in display (MagTag, PyPortal, PyGamer, PyBadge, CLUE, etc.)
 # see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
 # https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
 display = board.DISPLAY

--- a/examples/bitmap_font_label_simpletest.py
+++ b/examples/bitmap_font_label_simpletest.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-This example uses addfruit_display_text.label to display text using a custom font
+This example uses adafruit_display_text.label to display text using a custom font
 loaded by adafruit_bitmap_font
 """
 
@@ -10,7 +10,7 @@ import board
 from adafruit_display_text import label
 from adafruit_bitmap_font import bitmap_font
 
-# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# use built in display (MagTag, PyPortal, PyGamer, PyBadge, CLUE, etc.)
 # see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
 # https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
 display = board.DISPLAY


### PR DESCRIPTION
Some changes in the examples:

1. Exposing examples to the ReadtheDocs API
2. Using dynamic values for screen height and width
3. Including MagTag in the examples description
4. Correcting some typos.

Thanks for reviewing.