### PR TITLE
change simpletest script to work with CPython and CircuitPython

### DIFF
--- a/examples/bitmap_font_simpletest.py
+++ b/examples/bitmap_font_simpletest.py
@@ -12,15 +12,15 @@ from adafruit_bitmap_font import bitmap_font  # pylint: disable=wrong-import-pos
 font_file = "fonts/LeagueSpartan-Bold-16.bdf"
 
 # you can change the string that will get printed here
-specimen = "<3 Blinka"
+message = "<3 Blinka"
 
 font = bitmap_font.load_font(font_file)
 
 _, height, _, dy = font.get_bounding_box()
-font.load_glyphs(specimen)
+font.load_glyphs(message)
 
 for y in range(height):
-    for c in specimen:
+    for c in message:
         glyph = font.get_glyph(ord(c))
         if not glyph:
             continue

--- a/examples/bitmap_font_simpletest.py
+++ b/examples/bitmap_font_simpletest.py
@@ -1,18 +1,20 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-# Call this with the font file as the command line argument.
+"""
+This example loads a font and uses it to print an
+ASCII art representation of the given string specimen
+"""
 
-import os
-import sys
-
-# Add paths so this runs in CPython in-place.
-sys.path.append(os.path.join(sys.path[0], ".."))
 from adafruit_bitmap_font import bitmap_font  # pylint: disable=wrong-import-position
 
-sys.path.append(os.path.join(sys.path[0], "../test"))
-font = bitmap_font.load_font(sys.argv[1])
-specimen = "Adafruit CircuitPython" if len(sys.argv) == 2 else sys.argv[2]
+# you can change this to a different bdf or pcf font file
+font_file = "fonts/LeagueSpartan-Bold-16.bdf"
+
+# you can change the string that will get printed here
+specimen = "<3 Blinka"
+
+font = bitmap_font.load_font(font_file)
 
 _, height, _, dy = font.get_bounding_box()
 font.load_glyphs(specimen)


### PR DESCRIPTION
The current simpletest script is made specifically to be run with CPython and command line arguments. 

This PR changes the script to hardcode the font and string to generate into variables so that no command line arguments are used. 

The script can still run on CPython like:
```
python bitmap_font_simpletest.py
```
It can also now run on a CircuitPython device by saving in `code.py` or importing in REPL.