### PR TITLE
Fix AttributeError text

### DIFF
--- a/adafruit_bitmap_font/bdf.py
+++ b/adafruit_bitmap_font/bdf.py
@@ -103,7 +103,7 @@ class BDF(GlyphCache):
             self._boundingbox
         except AttributeError as error:
             raise Exception(
-                "Source file does not have the FOUNTBONDINGBOX parameter"
+                "Source file does not have the FOUNTBOUNDINGBOX parameter"
             ) from error
 
     def get_bounding_box(self):


### PR DESCRIPTION
The `AttributeError` raised when the bounding box parameter is missing has a typo, this fixes it!