### PR TITLE
adding note about font/ folder to examples

### DIFF
--- a/examples/bitmap_font_displayio_simpletest.py
+++ b/examples/bitmap_font_displayio_simpletest.py
@@ -19,6 +19,8 @@ from adafruit_bitmap_font import bitmap_font
 # https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
 display = board.DISPLAY
 
+# NOTE: You must copy the fonts/ folder from the
+# examples in the repo to your CIRCUITPY drive.
 # try uncommenting different font files if you like
 font_file = "fonts/LeagueSpartan-Bold-16.bdf"
 # font_file = "fonts/Junction-regular-24.pcf"

--- a/examples/bitmap_font_label_forkawesome.py
+++ b/examples/bitmap_font_label_forkawesome.py
@@ -19,6 +19,8 @@ from adafruit_bitmap_font import bitmap_font
 # https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
 display = board.DISPLAY
 
+# NOTE: You must copy the fonts/ folder from the
+# examples in the repo to your CIRCUITPY drive.
 font_file = "fonts/forkawesome-42.pcf"
 
 # Set text, font, and color

--- a/examples/bitmap_font_label_magtag.py
+++ b/examples/bitmap_font_label_magtag.py
@@ -21,6 +21,8 @@ display = board.DISPLAY
 # wait until we can refresh the display
 time.sleep(display.time_to_refresh)
 
+# NOTE: You must copy the fonts/ folder from the
+# examples in the repo to your CIRCUITPY drive.
 # try uncommenting different font files if you like
 font_file = "fonts/LeagueSpartan-Bold-16.bdf"
 # font_file = "fonts/Junction-regular-24.pcf"

--- a/examples/bitmap_font_label_simpletest.py
+++ b/examples/bitmap_font_label_simpletest.py
@@ -16,6 +16,8 @@ from adafruit_bitmap_font import bitmap_font
 # https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
 display = board.DISPLAY
 
+# NOTE: You must copy the fonts/ folder from the
+# examples in the repo to your CIRCUITPY drive.
 # try uncommenting different font files if you like
 font_file = "fonts/LeagueSpartan-Bold-16.bdf"
 # font_file = "fonts/Junction-regular-24.pcf"

--- a/examples/bitmap_font_lvgl_simpletest.py
+++ b/examples/bitmap_font_lvgl_simpletest.py
@@ -9,6 +9,8 @@ https://lvgl.io/tools/fontconverter
 
 from adafruit_bitmap_font import bitmap_font
 
+# NOTE: You must copy the fonts/ folder from the
+# examples in the repo to your CIRCUITPY drive.
 # Use the Japanese font file
 font_file = "fonts/unifont-16.0.02-ja.bin"
 

--- a/examples/bitmap_font_simpletest.py
+++ b/examples/bitmap_font_simpletest.py
@@ -8,6 +8,8 @@ ASCII art representation of the given string specimen
 
 from adafruit_bitmap_font import bitmap_font
 
+# NOTE: You must copy the fonts/ folder from the
+# examples in the repo to your CIRCUITPY drive.
 # you can change this to a different bdf or pcf font file
 font_file = "fonts/LeagueSpartan-Bold-16.bdf"
 


### PR DESCRIPTION
I believe this resolves: #72 

I had a quick look around and did not find any guide pages where the examples from this repo are embedded, so I'm still unsure if the bundler would grab these files automatically or not.